### PR TITLE
Add "-mhwacha4" to GCC

### DIFF
--- a/gcc/gcc/config/riscv/riscv.h
+++ b/gcc/gcc/config/riscv/riscv.h
@@ -58,6 +58,10 @@ along with GCC; see the file COPYING3.  If not see
         builtin_define ("__riscv_atomic");                              \
       }                                                                 \
                                                                         \
+      if (TARGET_HWACHA4) {                                             \
+        builtin_define ("__riscv_hwacha4");                             \
+      }                                                                 \
+                                                                        \
       /* These defines reflect the ABI in use, not whether the  	\
 	 FPU is directly accessible.  */				\
       if (TARGET_HARD_FLOAT_ABI) {					\

--- a/gcc/gcc/config/riscv/riscv.opt
+++ b/gcc/gcc/config/riscv/riscv.opt
@@ -77,3 +77,7 @@ Use LRA instead of reload
 mcmodel=
 Target RejectNegative Joined Var(riscv_cmodel_string)
 Use given RISC-V code model (medlow or medany)
+
+mhwacha4
+Target Report RejectNegative Mask(HWACHA4)
+Enable Hwacha v4 code generation


### PR DESCRIPTION
All this does is set __riscv_hwacha4 to be defined in user code.  As a
side-effect, it also defines TARGET_HWACHA4, which allows GCC to
control codegen for Hwacha v4 (but GCC doesn't do any codegen, so that
doesn't do anything).  I did this by pattern matching some existing
stuff, but it looks pretty much right (and at generates the define iff
passed the argument).

This allows me to ifdef in vector assembly for RISC-V benchmarks, so I
can mostly run the same code on RISC-V and Intel.
