### PR TITLE
Update vsetcfg immediate encoding

### DIFF
--- a/binutils/gas/config/tc-riscv.c
+++ b/binutils/gas/config/tc-riscv.c
@@ -1472,22 +1472,22 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
                 case 'g':
                   my_getExpression( imm_expr, s );
                   /* check_absolute_expr( ip, imm_expr ); */
-                  if ((unsigned long) imm_expr->X_add_number > NVGPR || 
-                      (unsigned long) imm_expr->X_add_number == 0)
+                  if ((unsigned long) imm_expr->X_add_number > NVGPR ||
+                      ((unsigned long) imm_expr->X_add_number & ~OP_MASK_IMMNGPR))
                     as_bad( _( "Improper ngpr amount (%lu)" ),
                              (unsigned long) imm_expr->X_add_number );
-                  INSERT_OPERAND( IMMNGPR, *ip, imm_expr->X_add_number - 1);
+                  INSERT_OPERAND( IMMNGPR, *ip, imm_expr->X_add_number );
                   imm_expr->X_op = O_absent;
                   s = expr_end;
                   continue;
                 case 'f':
                   my_getExpression( imm_expr, s );
                   /* check_absolute_expr( ip, imm_expr ); */
-                  if ((unsigned long) imm_expr->X_add_number > NVSPR || 
-                      (unsigned long) imm_expr->X_add_number == 0)
+                  if ((unsigned long) imm_expr->X_add_number > NVSPR ||
+                      ((unsigned long) imm_expr->X_add_number & ~OP_MASK_IMMNPPR))
                     as_bad( _( "Improper nppr amount (%lu)" ),
                              (unsigned long) imm_expr->X_add_number );
-                  INSERT_OPERAND( IMMNPPR, *ip, imm_expr->X_add_number - 1);
+                  INSERT_OPERAND( IMMNPPR, *ip, imm_expr->X_add_number );
                   imm_expr->X_op = O_absent;
                   s = expr_end;
                   continue;

--- a/binutils/include/opcode/riscv.h
+++ b/binutils/include/opcode/riscv.h
@@ -285,10 +285,10 @@ static const char * const riscv_hwacha_svbits[24] = {
 #define OP_MASK_VSUCC		0xf
 #define OP_SH_VSUCC		16
 
-#define OP_MASK_IMMNGPR         0xff
+#define OP_MASK_IMMNGPR         0x1ff
 #define OP_SH_IMMNGPR           20
-#define OP_MASK_IMMNPPR         0xf
-#define OP_SH_IMMNPPR           28
+#define OP_MASK_IMMNPPR         0x7
+#define OP_SH_IMMNPPR           29
 #define OP_MASK_IMMSEGNELM      0x7
 #define OP_SH_IMMSEGNELM        45
 #define OP_MASK_CUSTOM_IMM      0x7f


### PR DESCRIPTION
As discussed earlier:
- Provision 9 bits for `IMMNGPR` and 3 bits for `IMMNPPR`.
- Use "normal" integer encoding instead of biasing by -1 to enable representation of zero.
